### PR TITLE
Don't allow coordinator and legend together

### DIFF
--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -123,14 +123,15 @@ export namespace MilestoneAwardSelector {
         bind(ma.name, ma.name, 1000);
       });
 
-      bind(Terraformer, Benefactor, 9);
-      bind(Gardener, Cultivator, 9);
       bind(Builder, Contractor, 9);
+      bind(FullMoon, LunarMagnate, 9);
+      bind(Gardener, Cultivator, 9);
+      bind(Legend, Coordinator, 9);
+      bind(Lunarchitect, LunarMagnate, 9);
       bind(Networker, Entrepreneur, 9);
       bind(OneGiantStep, FullMoon, 9);
-      bind(Lunarchitect, LunarMagnate, 9);
       bind(OneGiantStep, Lunarchitect, 9);
-      bind(FullMoon, LunarMagnate, 9);
+      bind(Terraformer, Benefactor, 9);
       bind(EstateDealer, Cultivator, 8);
       bind(Landlord, Cultivator, 8);
       bind(Landlord, DesertSettler, 7);
@@ -305,7 +306,6 @@ export namespace MilestoneAwardSelector {
       bind(UrbanPlanner, Pioneer, 2);
 
       bind(Coordinator, Terraformer, 3);
-      bind(Coordinator, Legend, 5);
       bind(Coordinator, Benefactor, 4);
 
       bind(Importer, Energizer, 1);


### PR DESCRIPTION
* Decrease Legend/Coordinator possibility to go together
* Bonus: Alphabet order of the milestone/awards that shouldn't go together.